### PR TITLE
Patch/try reducing ci build flakiness

### DIFF
--- a/JTime-android/src/androidTest/java/com/ismail_s/jtime/android/activity/MainActivityEspressoTest.java
+++ b/JTime-android/src/androidTest/java/com/ismail_s/jtime/android/activity/MainActivityEspressoTest.java
@@ -49,8 +49,9 @@ public class MainActivityEspressoTest extends ActivityInstrumentationTestCase2<M
      * are very slim.
      */
     @BeforeClass
-    public static void unlockEmulator() throws IOException {
-        Runtime.getRuntime().exec("adb shell input keyevent 82");
+    public static void unlockEmulator() throws IOException,InterruptedException {
+        String command = "fb-adb shell input keyevent 82 || adb shell input keyevent 82";
+        Runtime.getRuntime().exec(command).waitFor();
     }
 
     @Before

--- a/JTime-android/src/androidTest/java/com/ismail_s/jtime/android/activity/MainActivityEspressoTest.java
+++ b/JTime-android/src/androidTest/java/com/ismail_s/jtime/android/activity/MainActivityEspressoTest.java
@@ -50,8 +50,10 @@ public class MainActivityEspressoTest extends ActivityInstrumentationTestCase2<M
      */
     @BeforeClass
     public static void unlockEmulator() throws IOException,InterruptedException {
-        String command = "fb-adb shell input keyevent 82 || adb shell input keyevent 82";
-        Runtime.getRuntime().exec(command).waitFor();
+        String command1 = "fb-adb shell input keyevent 82 || adb shell input keyevent 82";
+        String command2 = "fb-adb shell input keyevent 92 || adb shell input keyevent 92";
+        Runtime.getRuntime().exec(command1).waitFor();
+        Runtime.getRuntime().exec(command2).waitFor();
     }
 
     @Before

--- a/circle.yml
+++ b/circle.yml
@@ -27,6 +27,7 @@ test:
     # Sleeping isn't a brilliant fix...
     - sleep 30
     - fb-adb devices
+    # Unlock the lockscreen on the emulator
     - fb-adb shell input keyevent 82
     - fb-adb shell input keyevent 92
     - fb-adb rcmd screencap -p > $CIRCLE_ARTIFACTS/screen-$(date +"%T").png

--- a/circle.yml
+++ b/circle.yml
@@ -30,9 +30,9 @@ test:
     # Unlock the lockscreen on the emulator
     - fb-adb shell input keyevent 82
     - fb-adb shell input keyevent 92
-    - fb-adb rcmd screencap -p > $CIRCLE_ARTIFACTS/screen-$(timestamp).png
+    - fb-adb rcmd screencap -p > $CIRCLE_ARTIFACTS/screen-$(date +"%T").png
     - (cd JTime-android && ./gradlew connectedAndroidTest)
-    - fb-adb rcmd screencap -p > $CIRCLE_ARTIFACTS/screen-$(timestamp).png
+    - fb-adb rcmd screencap -p > $CIRCLE_ARTIFACTS/screen-$(date +"%T").png
   post:
     - cp -r JTime-android/build/outputs $CIRCLE_ARTIFACTS
     # copy the test results to the test results directory.

--- a/circle.yml
+++ b/circle.yml
@@ -20,19 +20,19 @@ test:
     - emulator -avd custom-android21-googleapis -no-audio -no-window:
         background: true
         parallel: true
-    - adb start-server:
+    - fb-adb start-server:
         background: true
     # wait for it to have booted
     - circle-android wait-for-boot
     # Sleeping isn't a brilliant fix...
     - sleep 30
-    - adb devices
+    - fb-adb devices
     # Unlock the lockscreen on the emulator
-    - adb shell input keyevent 82
-    - adb shell input keyevent 92
-    - adb shell screencap -p | perl -pe 's/\x0D\x0A/\x0A/g' > $CIRCLE_ARTIFACTS/screen.png
+    - fb-adb shell input keyevent 82
+    - fb-adb shell input keyevent 92
+    - fb-adb rcmd screencap -p > $CIRCLE_ARTIFACTS/screen-$(timestamp).png
     - (cd JTime-android && ./gradlew connectedAndroidTest)
-    - adb shell screencap -p | perl -pe 's/\x0D\x0A/\x0A/g' > $CIRCLE_ARTIFACTS/screen1.png
+    - fb-adb rcmd screencap -p > $CIRCLE_ARTIFACTS/screen-$(timestamp).png
   post:
     - cp -r JTime-android/build/outputs $CIRCLE_ARTIFACTS
     # copy the test results to the test results directory.

--- a/circle.yml
+++ b/circle.yml
@@ -27,6 +27,8 @@ test:
     # Sleeping isn't a brilliant fix...
     - sleep 30
     - fb-adb devices
+    - fb-adb shell input keyevent 82
+    - fb-adb shell input keyevent 92
     - fb-adb rcmd screencap -p > $CIRCLE_ARTIFACTS/screen-$(date +"%T").png
     # Note the espresso tests include code to unlock the emulator before running the tests
     - (cd JTime-android && ./gradlew connectedAndroidTest)

--- a/circle.yml
+++ b/circle.yml
@@ -27,10 +27,8 @@ test:
     # Sleeping isn't a brilliant fix...
     - sleep 30
     - fb-adb devices
-    # Unlock the lockscreen on the emulator
-    - fb-adb shell input keyevent 82
-    - fb-adb shell input keyevent 92
     - fb-adb rcmd screencap -p > $CIRCLE_ARTIFACTS/screen-$(date +"%T").png
+    # Note the espresso tests include code to unlock the emulator before running the tests
     - (cd JTime-android && ./gradlew connectedAndroidTest)
     - fb-adb rcmd screencap -p > $CIRCLE_ARTIFACTS/screen-$(date +"%T").png
   post:


### PR DESCRIPTION
Some things I've done:

- Use fb-adb instead of adb
- Run fb-adb/adb just before running tests, and wait for the commands to finish running

This seems to work relatively reliably. But the better solution to do in the future would be to restart the emulator or something if the tests don't work first time round.