### PR TITLE
Fix ci builds

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,9 +15,9 @@ test:
     # robolectric
     #- (cd JTime-android && (./gradlew test assembleDebug || ./gradlew test assembleDebug))
     - (cd JTime-android &&./gradlew assembleDebug)
-    - android create avd -n custom-android21-googleapis -t "android-21" --abi google_apis/armeabi-v7a
+    - echo | android create avd -n custom-android21-googleapis -t "android-21" --abi google_apis/armeabi-v7a
   # start the emulator
-    - echo | emulator -avd custom-android21-googleapis -no-audio -no-window:
+    - emulator -avd custom-android21-googleapis -no-audio -no-window:
         background: true
         parallel: true
     - fb-adb start-server:

--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,7 @@ test:
     - (cd JTime-android &&./gradlew assembleDebug)
     - android create avd -n custom-android21-googleapis -t "Google Inc.:Google APIs:21" --abi google_apis/armeabi-v7a
   # start the emulator
-    - emulator -avd custom-android21-googleapis -no-audio -no-window:
+    - emulator -avd circleci-android21 -no-audio -no-window:
         background: true
         parallel: true
     - fb-adb start-server:

--- a/circle.yml
+++ b/circle.yml
@@ -15,9 +15,9 @@ test:
     # robolectric
     #- (cd JTime-android && (./gradlew test assembleDebug || ./gradlew test assembleDebug))
     - (cd JTime-android &&./gradlew assembleDebug)
-    - android create avd -n custom-android21-googleapis -t "Google Inc.:Google APIs:21" --abi google_apis/armeabi-v7a
+    - android create avd -n custom-android21-googleapis -t "android-21" --abi google_apis/armeabi-v7a
   # start the emulator
-    - emulator -avd circleci-android21 -no-audio -no-window:
+    - emulator -avd custom-android21-googleapis -no-audio -no-window:
         background: true
         parallel: true
     - fb-adb start-server:

--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,7 @@ test:
     - (cd JTime-android &&./gradlew assembleDebug)
     - android create avd -n custom-android21-googleapis -t "android-21" --abi google_apis/armeabi-v7a
   # start the emulator
-    - emulator -avd custom-android21-googleapis -no-audio -no-window:
+    - echo | emulator -avd custom-android21-googleapis -no-audio -no-window:
         background: true
         parallel: true
     - fb-adb start-server:


### PR DESCRIPTION
For some reason, circleci seem to have removed the abi for the emulator target thingy I was using up till now. So this PR switches to using a new emulator target thingy, which seems to work.