### PR TITLE
Version 1.5.0 (again)

### DIFF
--- a/JTime-android/build.gradle
+++ b/JTime-android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:${dokka_version}"
         classpath 'com.google.gms:google-services:2.0.0-alpha5'
-        classpath 'com.github.triplet.gradle:play-publisher:1.1.4'
+        classpath 'com.github.triplet.gradle:play-publisher:1.1.5'
     }
 }
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -7,5 +7,5 @@ def deploy():
         run('git stash && git pull && git stash pop')
         run('npm install .')
         rsync_project(remote_dir = '~/JTime/JTime-rest/client/jtime-website',
-                      local_dir = 'JTime-rest/client/jtime-website/build')
+                      local_dir = 'JTime-rest/client/jtime-website/dist')
         run('pm2 reload .')


### PR DESCRIPTION
- Upgrade Gradle Play Publisher plugin, which should fix the deployment of the Android app not working
- Fix rsync command, which should fix the website deployment not working