### PR TITLE
Version 1.6.1(yet again)

### DIFF
--- a/JTime-rest/run-server.js
+++ b/JTime-rest/run-server.js
@@ -20,7 +20,7 @@ child.on('exit', function () {
 child.start()
 
 setInterval(function () {
-  fs.access(flagFile, fs.constants.F_OK, function (err) {
+  fs.access(flagFile, function (err) {
     if (err) {
       // File doesn't exist, nothing to do
       return

--- a/JTime-rest/server/server.js
+++ b/JTime-rest/server/server.js
@@ -3,11 +3,6 @@ var boot = require('loopback-boot')
 
 var app = module.exports = loopback()
 
-// Enable http session
-app.use(loopback.session({
-  secret: 'some secret...TODO-change this'
-}))
-
 boot(app, __dirname)
 
 app.start = function () {


### PR DESCRIPTION
Remove unused cookie session codeRemove unused cookie session code

This is a change I was meant to make some time ago. The reason for doing it here is to trigger a redeploy of the rest api.